### PR TITLE
Race Condition in Retrieval of Container PID

### DIFF
--- a/nova-driver/driver.py
+++ b/nova-driver/driver.py
@@ -8,6 +8,7 @@ import os
 import socket
 import base64
 import random
+import time
 
 from oslo.config import cfg
 
@@ -113,6 +114,9 @@ class DockerDriver(driver.ComputeDriver):
         cgroup_path = self._find_cgroup_devices_path()
         lxc_path = os.path.join(cgroup_path, 'lxc')
         tasks_path = os.path.join(lxc_path, container_id, 'tasks')
+        
+        time.sleep(1)
+        
         with open(tasks_path) as f:
             pids = f.readlines()
             if not pids:


### PR DESCRIPTION
I was/am struggling with getting Docker instances to boot up properly. The exception can be traced down to `_find_container_pid` in the  driver. It can't find that `tasks` file.

From the logs and some debugging I could see though that the instance was created and the file was actually there and contained the PID.

It seems there is a race condition or a small startup delay. Adding the sleep solved the problem for testing purposes. Unfortunately I don't really know how to solve that problem idiomatically. So, consider this a heads up that there is something going on here...

Impressive how simple the integration is. Docker is quite cool!
