### PR TITLE
Updated api.py

### DIFF
--- a/glance-db-backend/api.py
+++ b/glance-db-backend/api.py
@@ -109,7 +109,8 @@ def image_get(context, image_id, session=None, force_show_deleted=False):
 @log_call
 def image_get_all(context, filters=None, marker=None, limit=None,
                   sort_key='created_at', sort_dir='desc',
-                  member_status='accepted', is_public=None):
+                  member_status='accepted', is_public=None,
+                  admin_as_user=False):
     _init_cache()
     return [_image_format(i) for i in IMAGES_CACHE]
 


### PR DESCRIPTION
Glance image-list call was failing when called by admin user due to unexpected kwarg admin_as_user in image_get_all.
